### PR TITLE
SRE-2775 Update github actions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout current tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_GITHUB_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-node@v4
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -34,12 +34,12 @@ jobs:
     needs: [tag]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.17
         id: go

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -32,13 +32,13 @@ jobs:
     steps:
 
     - name: Setup Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: "refs/pull/${{ github.event.number }}/merge"
 
@@ -56,13 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: "refs/pull/${{ github.event.number }}/merge"
 
     - name: Setup Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go

--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -35,13 +35,13 @@ jobs:
     steps:
 
     - name: Setup Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Test
       run: go test -coverprofile cover.out ./...
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
     - name: Setup Go
-      uses: actions/setup-go@v4.1.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.17
       id: go


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use specific commit SHA references for third-party actions instead of version tags. This improves security by ensuring that the workflows always use the exact, reviewed versions of each action. It also updates some actions to newer major versions.

Key changes by theme:

**Security and Stability Improvements:**

* All usages of `actions/checkout`, `actions/setup-go`, and `aws-actions/configure-aws-credentials` in workflow files are now pinned to specific commit SHAs instead of version tags, ensuring reproducibility and reducing the risk of supply chain attacks. [[1]](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL20-R23) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L38-R38) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R42) [[5]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L14-R20) [[6]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L35-R41) [[7]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L59-R65) [[8]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL17-R23) [[9]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL38-R44) [[10]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL60-R65)

**Dependency Updates:**

* Upgraded `actions/checkout` to v7.0.0 (by SHA) across all workflows, replacing older v3 and v4 usages. [[1]](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL20-R23) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L38-R38) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R42) [[5]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L14-R20) [[6]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L35-R41) [[7]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L59-R65) [[8]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL17-R23) [[9]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL38-R44) [[10]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL60-R65)
* Updated `actions/setup-go` to v6.4.0 (by SHA) in all relevant jobs, replacing v4.1.0. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R42) [[2]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L14-R20) [[3]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L35-R41) [[4]](diffhunk://#diff-835bac5dafbdf4c2fa664d693e5a1cc10647840fcb6359cd293300b919334463L59-R65) [[5]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL17-R23) [[6]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL38-R44) [[7]](diffhunk://#diff-ad3c698e2e41ee1a5b9c339bc8742b0bf4792a242d22c172dcca3fc69f43c17fL60-R65)
* Updated `aws-actions/configure-aws-credentials` to v6.2.0 (by SHA) in the build and push workflow.