### PR TITLE
feat: Add `phpfpm_pod` to metric labels

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
 version: "2"
 linters:
   default: none
+  settings:
+    goconst:
+      min-occurrences: 5
   enable:
     - dupl
     - errcheck

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Run the exporter with Kubernetes discovery enabled:
 php-fpm_exporter server --k8s.autotracking --k8s.namespace my-namespace --k8s.pod-labels 'php-fpm-exporter/collect=true'
 ```
 
-When Kubernetes auto-tracking is enabled, every emitted metric includes a `pod` label populated with the discovered pod name. Static `--phpfpm.scrape-uri` targets still expose the `pod` label with an empty value.
+When Kubernetes auto-tracking is enabled, every emitted metric includes a `phpfpm_pod` label populated with the discovered PHP-FPM pod name. Static `--phpfpm.scrape-uri` targets still expose `phpfpm_pod` with an empty value.
 
 ## Metrics collected
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ If you like to have a more granular reporting please use `phpfpm_process_state`.
 
 ### Kubernetes Example
 
-TBD
+Run the exporter with Kubernetes discovery enabled:
+
+```bash
+php-fpm_exporter server --k8s.autotracking --k8s.namespace my-namespace --k8s.pod-labels 'php-fpm-exporter/collect=true'
+```
+
+When Kubernetes auto-tracking is enabled, every emitted metric includes a `pod` label populated with the discovered pod name. Static `--phpfpm.scrape-uri` targets still expose the `pod` label with an empty value.
 
 ## Metrics collected
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -43,7 +43,7 @@ var getCmd = &cobra.Command{
 		pm.ScrapeTimeout = scrapeTimeout
 
 		for _, uri := range scrapeURIs {
-			pm.Add(uri)
+			pm.Add(uri, "")
 		}
 
 		if err := pm.Update(); err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -74,7 +74,7 @@ to quickly create a Cobra application.`,
 		} else {
 			// Static scraping of predefined URIs
 			for _, uri := range scrapeURIs {
-				pm.Add(uri)
+				pm.Add(uri, "")
 			}
 			exporter.UpdatePoolManager(pm)
 		}

--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -25,6 +25,24 @@ const (
 	namespace = "phpfpm"
 )
 
+var (
+	poolMetricLabels         = []string{"pool", "pod", "scrape_uri"}
+	processMetricLabels      = []string{"pool", "pod", "child", "scrape_uri"}
+	processStateMetricLabels = []string{"pool", "pod", "child", "state", "scrape_uri"}
+)
+
+func poolLabelValues(pool Pool) []string {
+	return []string{pool.Name, pool.Pod, pool.Address}
+}
+
+func processLabelValues(pool Pool, child string) []string {
+	return []string{pool.Name, pool.Pod, child, pool.Address}
+}
+
+func processStateLabelValues(pool Pool, child string, state string) []string {
+	return []string{pool.Name, pool.Pod, child, state, pool.Address}
+}
+
 // Exporter configures and exposes PHP-FPM metrics to Prometheus.
 type Exporter struct {
 	mutex       sync.Mutex
@@ -62,109 +80,109 @@ func NewExporter(pm PoolManager) *Exporter {
 		up: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "up"),
 			"Could PHP-FPM be reached?",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		scrapeFailues: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "scrape_failures"),
 			"The number of failures scraping from PHP-FPM.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		startSince: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "start_since"),
 			"The number of seconds since FPM has started.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		acceptedConnections: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "accepted_connections"),
 			"The number of requests accepted by the pool.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		listenQueue: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "listen_queue"),
 			"The number of requests in the queue of pending connections.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		maxListenQueue: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "max_listen_queue"),
 			"The maximum number of requests in the queue of pending connections since FPM has started.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		listenQueueLength: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "listen_queue_length"),
 			"The size of the socket queue of pending connections.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		idleProcesses: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "idle_processes"),
 			"The number of idle processes.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		activeProcesses: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "active_processes"),
 			"The number of active processes.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		totalProcesses: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "total_processes"),
 			"The number of idle + active processes.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		maxActiveProcesses: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "max_active_processes"),
 			"The maximum number of active processes since FPM has started.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		maxChildrenReached: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "max_children_reached"),
 			"The number of times, the process limit has been reached, when pm tries to start more children (works only for pm 'dynamic' and 'ondemand').",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		slowRequests: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "slow_requests"),
 			"The number of requests that exceeded your 'request_slowlog_timeout' value.",
-			[]string{"pool", "scrape_uri"},
+			poolMetricLabels,
 			nil),
 
 		processRequests: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "process_requests"),
 			"The number of requests the process has served.",
-			[]string{"pool", "child", "scrape_uri"},
+			processMetricLabels,
 			nil),
 
 		processLastRequestMemory: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "process_last_request_memory"),
 			"The max amount of memory the last request consumed.",
-			[]string{"pool", "child", "scrape_uri"},
+			processMetricLabels,
 			nil),
 
 		processLastRequestCPU: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "process_last_request_cpu"),
 			"The %cpu the last request consumed.",
-			[]string{"pool", "child", "scrape_uri"},
+			processMetricLabels,
 			nil),
 
 		processRequestDuration: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "process_request_duration"),
 			"The duration in microseconds of the requests.",
-			[]string{"pool", "child", "scrape_uri"},
+			processMetricLabels,
 			nil),
 
 		processState: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "process_state"),
 			"The state of the process (Idle, Running, ...).",
-			[]string{"pool", "child", "state", "scrape_uri"},
+			processStateMetricLabels,
 			nil),
 	}
 }
@@ -178,11 +196,17 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		log.Error(err)
 	}
 
-	for _, pool := range e.PoolManager.Pools {
-		ch <- prometheus.MustNewConstMetric(e.scrapeFailues, prometheus.CounterValue, float64(pool.ScrapeFailures), pool.Name, pool.Address)
+	e.collectPools(ch, e.PoolManager.Pools)
+}
+
+func (e *Exporter) collectPools(ch chan<- prometheus.Metric, pools []Pool) {
+	for _, pool := range pools {
+		poolValues := poolLabelValues(pool)
+
+		ch <- prometheus.MustNewConstMetric(e.scrapeFailues, prometheus.CounterValue, float64(pool.ScrapeFailures), poolValues...)
 
 		if pool.ScrapeError != nil {
-			ch <- prometheus.MustNewConstMetric(e.up, prometheus.GaugeValue, 0, pool.Name, pool.Address)
+			ch <- prometheus.MustNewConstMetric(e.up, prometheus.GaugeValue, 0, poolValues...)
 			log.Errorf("Error scraping PHP-FPM: %v", pool.ScrapeError)
 			continue
 		}
@@ -198,21 +222,22 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			total = pool.TotalProcesses
 		}
 
-		ch <- prometheus.MustNewConstMetric(e.up, prometheus.GaugeValue, 1, pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.startSince, prometheus.CounterValue, float64(pool.StartSince), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.acceptedConnections, prometheus.CounterValue, float64(pool.AcceptedConnections), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.listenQueue, prometheus.GaugeValue, float64(pool.ListenQueue), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.maxListenQueue, prometheus.CounterValue, float64(pool.MaxListenQueue), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.listenQueueLength, prometheus.GaugeValue, float64(pool.ListenQueueLength), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.idleProcesses, prometheus.GaugeValue, float64(idle), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.activeProcesses, prometheus.GaugeValue, float64(active), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.totalProcesses, prometheus.GaugeValue, float64(total), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.maxActiveProcesses, prometheus.CounterValue, float64(pool.MaxActiveProcesses), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.maxChildrenReached, prometheus.CounterValue, float64(pool.MaxChildrenReached), pool.Name, pool.Address)
-		ch <- prometheus.MustNewConstMetric(e.slowRequests, prometheus.CounterValue, float64(pool.SlowRequests), pool.Name, pool.Address)
+		ch <- prometheus.MustNewConstMetric(e.up, prometheus.GaugeValue, 1, poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.startSince, prometheus.CounterValue, float64(pool.StartSince), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.acceptedConnections, prometheus.CounterValue, float64(pool.AcceptedConnections), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.listenQueue, prometheus.GaugeValue, float64(pool.ListenQueue), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.maxListenQueue, prometheus.CounterValue, float64(pool.MaxListenQueue), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.listenQueueLength, prometheus.GaugeValue, float64(pool.ListenQueueLength), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.idleProcesses, prometheus.GaugeValue, float64(idle), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.activeProcesses, prometheus.GaugeValue, float64(active), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.totalProcesses, prometheus.GaugeValue, float64(total), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.maxActiveProcesses, prometheus.CounterValue, float64(pool.MaxActiveProcesses), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.maxChildrenReached, prometheus.CounterValue, float64(pool.MaxChildrenReached), poolValues...)
+		ch <- prometheus.MustNewConstMetric(e.slowRequests, prometheus.CounterValue, float64(pool.SlowRequests), poolValues...)
 
 		for childNumber, process := range pool.Processes {
 			childName := fmt.Sprintf("%d", childNumber)
+			processValues := processLabelValues(pool, childName)
 
 			states := map[string]int{
 				PoolProcessRequestIdle:           0,
@@ -225,12 +250,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			states[process.State]++
 
 			for stateName, inState := range states {
-				ch <- prometheus.MustNewConstMetric(e.processState, prometheus.GaugeValue, float64(inState), pool.Name, childName, stateName, pool.Address)
+				ch <- prometheus.MustNewConstMetric(e.processState, prometheus.GaugeValue, float64(inState), processStateLabelValues(pool, childName, stateName)...)
 			}
-			ch <- prometheus.MustNewConstMetric(e.processRequests, prometheus.CounterValue, float64(process.Requests), pool.Name, childName, pool.Address)
-			ch <- prometheus.MustNewConstMetric(e.processLastRequestMemory, prometheus.GaugeValue, float64(process.LastRequestMemory), pool.Name, childName, pool.Address)
-			ch <- prometheus.MustNewConstMetric(e.processLastRequestCPU, prometheus.GaugeValue, process.LastRequestCPU, pool.Name, childName, pool.Address)
-			ch <- prometheus.MustNewConstMetric(e.processRequestDuration, prometheus.GaugeValue, float64(process.RequestDuration), pool.Name, childName, pool.Address)
+			ch <- prometheus.MustNewConstMetric(e.processRequests, prometheus.CounterValue, float64(process.Requests), processValues...)
+			ch <- prometheus.MustNewConstMetric(e.processLastRequestMemory, prometheus.GaugeValue, float64(process.LastRequestMemory), processValues...)
+			ch <- prometheus.MustNewConstMetric(e.processLastRequestCPU, prometheus.GaugeValue, process.LastRequestCPU, processValues...)
+			ch <- prometheus.MustNewConstMetric(e.processRequestDuration, prometheus.GaugeValue, float64(process.RequestDuration), processValues...)
 		}
 	}
 }
@@ -238,6 +263,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 // Describe exposes the metric description to Prometheus
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.up
+	ch <- e.scrapeFailues
 	ch <- e.startSince
 	ch <- e.acceptedConnections
 	ch <- e.listenQueue

--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -22,14 +22,13 @@ import (
 )
 
 const (
-	namespace      = "phpfpm"
-	phpfpmPodLabel = "phpfpm_pod"
+	namespace = "phpfpm"
 )
 
 var (
-	poolMetricLabels         = []string{"pool", phpfpmPodLabel, "scrape_uri"}
-	processMetricLabels      = []string{"pool", phpfpmPodLabel, "child", "scrape_uri"}
-	processStateMetricLabels = []string{"pool", phpfpmPodLabel, "child", "state", "scrape_uri"}
+	poolMetricLabels         = []string{"pool", "phpfpm_pod", "scrape_uri"}
+	processMetricLabels      = []string{"pool", "phpfpm_pod", "child", "scrape_uri"}
+	processStateMetricLabels = []string{"pool", "phpfpm_pod", "child", "state", "scrape_uri"}
 )
 
 func poolLabelValues(pool Pool) []string {

--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -22,13 +22,14 @@ import (
 )
 
 const (
-	namespace = "phpfpm"
+	namespace      = "phpfpm"
+	phpfpmPodLabel = "phpfpm_pod"
 )
 
 var (
-	poolMetricLabels         = []string{"pool", "phpfpm_pod", "scrape_uri"}
-	processMetricLabels      = []string{"pool", "phpfpm_pod", "child", "scrape_uri"}
-	processStateMetricLabels = []string{"pool", "phpfpm_pod", "child", "state", "scrape_uri"}
+	poolMetricLabels         = []string{"pool", phpfpmPodLabel, "scrape_uri"}
+	processMetricLabels      = []string{"pool", phpfpmPodLabel, "child", "scrape_uri"}
+	processStateMetricLabels = []string{"pool", phpfpmPodLabel, "child", "state", "scrape_uri"}
 )
 
 func poolLabelValues(pool Pool) []string {

--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -26,9 +26,9 @@ const (
 )
 
 var (
-	poolMetricLabels         = []string{"pool", "pod", "scrape_uri"}
-	processMetricLabels      = []string{"pool", "pod", "child", "scrape_uri"}
-	processStateMetricLabels = []string{"pool", "pod", "child", "state", "scrape_uri"}
+	poolMetricLabels         = []string{"pool", "phpfpm_pod", "scrape_uri"}
+	processMetricLabels      = []string{"pool", "phpfpm_pod", "child", "scrape_uri"}
+	processStateMetricLabels = []string{"pool", "phpfpm_pod", "child", "state", "scrape_uri"}
 )
 
 func poolLabelValues(pool Pool) []string {

--- a/phpfpm/exporter_test.go
+++ b/phpfpm/exporter_test.go
@@ -23,10 +23,10 @@ func TestPoolManagerAddStoresPodName(t *testing.T) {
 func TestNewExporterDescriptorsIncludePodLabel(t *testing.T) {
 	exporter := NewExporter(PoolManager{})
 
-	assert.Contains(t, exporter.up.String(), "variableLabels: {pool,pod,scrape_uri}")
-	assert.Contains(t, exporter.scrapeFailues.String(), "variableLabels: {pool,pod,scrape_uri}")
-	assert.Contains(t, exporter.processRequests.String(), "variableLabels: {pool,pod,child,scrape_uri}")
-	assert.Contains(t, exporter.processState.String(), "variableLabels: {pool,pod,child,state,scrape_uri}")
+	assert.Contains(t, exporter.up.String(), "variableLabels: {pool,phpfpm_pod,scrape_uri}")
+	assert.Contains(t, exporter.scrapeFailues.String(), "variableLabels: {pool,phpfpm_pod,scrape_uri}")
+	assert.Contains(t, exporter.processRequests.String(), "variableLabels: {pool,phpfpm_pod,child,scrape_uri}")
+	assert.Contains(t, exporter.processState.String(), "variableLabels: {pool,phpfpm_pod,child,state,scrape_uri}")
 }
 
 func TestExporterDescribeIncludesScrapeFailuresDescriptor(t *testing.T) {
@@ -94,7 +94,7 @@ func TestExporterCollectPoolsIncludesPodLabel(t *testing.T) {
 
 				dtoMetric := &dto.Metric{}
 				require.NoError(t, metric.Write(dtoMetric))
-				assertMetricLabelValue(t, dtoMetric.GetLabel(), "pod", tt.pod)
+				assertMetricLabelValue(t, dtoMetric.GetLabel(), "phpfpm_pod", tt.pod)
 			}
 
 			assert.NotZero(t, metricCount)

--- a/phpfpm/exporter_test.go
+++ b/phpfpm/exporter_test.go
@@ -1,0 +1,116 @@
+package phpfpm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolManagerAddStoresPodName(t *testing.T) {
+	pm := PoolManager{}
+
+	pool := pm.Add("tcp://10.0.0.1:9000/status", "php-fpm-0")
+
+	assert.Equal(t, "php-fpm-0", pool.Pod)
+	require.Len(t, pm.Pools, 1)
+	assert.Equal(t, "php-fpm-0", pm.Pools[0].Pod)
+}
+
+func TestNewExporterDescriptorsIncludePodLabel(t *testing.T) {
+	exporter := NewExporter(PoolManager{})
+
+	assert.Contains(t, exporter.up.String(), "variableLabels: {pool,pod,scrape_uri}")
+	assert.Contains(t, exporter.scrapeFailues.String(), "variableLabels: {pool,pod,scrape_uri}")
+	assert.Contains(t, exporter.processRequests.String(), "variableLabels: {pool,pod,child,scrape_uri}")
+	assert.Contains(t, exporter.processState.String(), "variableLabels: {pool,pod,child,state,scrape_uri}")
+}
+
+func TestExporterDescribeIncludesScrapeFailuresDescriptor(t *testing.T) {
+	exporter := NewExporter(PoolManager{})
+	descs := make(chan *prometheus.Desc, 32)
+
+	exporter.Describe(descs)
+	close(descs)
+
+	foundScrapeFailures := false
+	descCount := 0
+
+	for desc := range descs {
+		descCount++
+		if strings.Contains(desc.String(), "phpfpm_scrape_failures") {
+			foundScrapeFailures = true
+		}
+	}
+
+	assert.True(t, foundScrapeFailures)
+	assert.Equal(t, 18, descCount)
+}
+
+func TestExporterCollectPoolsIncludesPodLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  string
+	}{
+		{name: "kubernetes discovered target", pod: "php-fpm-0"},
+		{name: "static target", pod: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := NewExporter(PoolManager{})
+			exporter.CountProcessState = true
+
+			ch := make(chan prometheus.Metric, 64)
+			exporter.collectPools(ch, []Pool{
+				{
+					Address:             "tcp://10.0.0.1:9000/status",
+					Pod:                 tt.pod,
+					Name:                "www",
+					StartSince:          1,
+					AcceptedConnections: 2,
+					ListenQueueLength:   128,
+					MaxActiveProcesses:  1,
+					Processes: []PoolProcess{
+						{
+							State:             PoolProcessRequestRunning,
+							Requests:          3,
+							RequestDuration:   10,
+							LastRequestCPU:    12.5,
+							LastRequestMemory: 2048,
+						},
+					},
+				},
+			})
+			close(ch)
+
+			metricCount := 0
+
+			for metric := range ch {
+				metricCount++
+
+				dtoMetric := &dto.Metric{}
+				require.NoError(t, metric.Write(dtoMetric))
+				assertMetricLabelValue(t, dtoMetric.GetLabel(), "pod", tt.pod)
+			}
+
+			assert.NotZero(t, metricCount)
+		})
+	}
+}
+
+func assertMetricLabelValue(t *testing.T, labels []*dto.LabelPair, name string, want string) {
+	t.Helper()
+
+	for _, label := range labels {
+		if label.GetName() == name {
+			assert.Equal(t, want, label.GetValue())
+			return
+		}
+	}
+
+	t.Fatalf("label %q not found", name)
+}

--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -88,6 +88,7 @@ type PoolManager struct {
 type Pool struct {
 	// The address of the pool, e.g. tcp://127.0.0.1:9000 or unix:///tmp/php-fpm.sock
 	Address             string        `json:"-"`
+	Pod                 string        `json:"pod,omitempty"`
 	ScrapeError         error         `json:"-"`
 	ScrapeFailures      int64         `json:"-"`
 	Name                string        `json:"pool"`
@@ -136,9 +137,9 @@ type PoolProcessStateCounter struct {
 	Ending         int64
 }
 
-// Add will add a pool to the pool manager based on the given URI.
-func (pm *PoolManager) Add(uri string) Pool {
-	p := Pool{Address: uri}
+// Add will add a pool to the pool manager based on the given URI and pod name.
+func (pm *PoolManager) Add(uri string, pod string) Pool {
+	p := Pool{Address: uri, Pod: pod}
 	pm.Pools = append(pm.Pools, p)
 	return p
 }

--- a/phpfpm/pod_discovery.go
+++ b/phpfpm/pod_discovery.go
@@ -99,7 +99,7 @@ func (pm *PoolManager) handlePodRunning(exporter *Exporter, pod *v1.Pod, uri str
 	podName := pod.Name
 	if ip != "" {
 		log.Infof("Pod in Running state detected %s with IP %s. Adding in the Pool Manager..", podName, ip)
-		pm.Add(uri)
+		pm.Add(uri, podName)
 		exporter.UpdatePoolManager(*pm)
 	} else {
 		log.Debugf("Pod %s is in Running state but has no IP assigned", podName)


### PR DESCRIPTION
This PR adds the label `phpfpm_pod` to the exporter metrics with value the name of the pod being scraped.

*As the `pod` label is occupied by the fpm-exporter pod name `phpfpm_pod` was chosen*

> [!NOTE]
> Lint was being unreasonable so goconst min-occurences was raised to 5


Tested in dev: [example](https://dash.sre-infra-k8s.prod.aws.htb.systems/goto/dfu99bnvm8f0gd?orgId=1)